### PR TITLE
Add ML5 WebXR playground example

### DIFF
--- a/examples/boilerplate/ml5-playground/index.html
+++ b/examples/boilerplate/ml5-playground/index.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>ML5 WebXR Playground • A-Frame</title>
+    <meta name="description" content="ML5 WebXR Playground • A-Frame">
+    <script src="../../../dist/aframe-master.js"></script>
+    <script src="https://unpkg.com/ml5@latest/dist/ml5.min.js"></script>
+  </head>
+  <body>
+    <a-scene vr-mode-ui="enabled: true">
+      <a-assets>
+        <video id="video" autoplay playsinline webkit-playsinline muted></video>
+      </a-assets>
+
+      <a-plane src="#video" position="0 1.5 -2" width="1.6" height="0.9"></a-plane>
+      <a-text id="label" value="Loading…" position="-0.7 0.5 -1" color="#FFF"></a-text>
+    </a-scene>
+
+    <script>
+      const video = document.getElementById('video');
+
+      navigator.mediaDevices.getUserMedia({ video: true }).then(stream => {
+        video.srcObject = stream;
+      });
+
+      const classifier = ml5.imageClassifier('MobileNet', () => {
+        classify();
+      });
+
+      function classify () {
+        classifier.classify(video, (err, results) => {
+          if (err) {
+            console.error(err);
+            return;
+          }
+          document.getElementById('label').setAttribute('value', results[0].label);
+          classify();
+        });
+      }
+    </script>
+  </body>
+</html>

--- a/examples/index.html
+++ b/examples/index.html
@@ -155,6 +155,7 @@
       <li><a href="boilerplate/panorama/">360&deg; Image</a></li>
       <li><a href="boilerplate/360-video/">360&deg; Video</a></li>
       <li><a href="boilerplate/3d-model/">3D Model (glTF)</a></li>
+      <li><a href="boilerplate/ml5-playground/">ML5 WebXR Playground</a></li>
       <li><a href="mixed-reality/anchor/">Anchor (Mixed Reality)</a></li>
       <li><a href="mixed-reality/real-world-meshing/">Real World Meshing (Mixed Reality)</a></li>
       <li><a href="mixed-reality/watch/">Virtual Watch (Mixed Reality)</a></li>


### PR DESCRIPTION
## Summary
- add a boilerplate example using ml5.js with A-Frame and WebXR
- list the new example in the examples index

## Testing
- `npm test` *(fails: Cannot find Firefox or Chrome binaries)*
- `npm run test:nobrowser` *(fails: No captured browser, open http://localhost:9876/)*


------
https://chatgpt.com/codex/tasks/task_e_689e8385fae4832aa6b022bfeb8d153d